### PR TITLE
Add enum, assertion to GenerateImage

### DIFF
--- a/lib/src/model/gen_image/request/generate_image.dart
+++ b/lib/src/model/gen_image/request/generate_image.dart
@@ -1,3 +1,18 @@
+///The size of the generated images.
+enum GeneratedImageSize {
+  size1024("1024x1024"),
+  size512("512x512"),
+  size256("256x256");
+
+  const GeneratedImageSize(this.size);
+  final String size;
+}
+
+enum GeneratedResponseFormat {
+  url,
+  b64_json;
+}
+
 class GenerateImage {
   /// prompt string Required A text description of the desired image(s). The maximum length is 1000 characters.
   final String prompt;
@@ -14,14 +29,30 @@ class GenerateImage {
   ///A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
   final String user;
 
-  GenerateImage(this.prompt, this.n,
-      {this.size = "1024x1024", this.response_format = "url", this.user = ""});
+  GenerateImage(
+    this.prompt,
+    this.n, {
+    String? size,
+    GeneratedImageSize? generateImageSize,
+    String? response_format,
+    GeneratedResponseFormat? generatedResponseFormat,
+    this.user = "",
+  })  : assert((size == null) || (generateImageSize == null),
+            'size and generatedImageSize  must not both be valid.'),
+        assert((response_format == null) || (generatedResponseFormat == null),
+            'response_format and generatedResponseFormat  must not both be valid.'),
+        assert(1 <= n && n <= 10, 'n must be between 1 and 10.'),
+        this.size =
+            size ?? generateImageSize?.size ?? GeneratedImageSize.size1024.size,
+        this.response_format = response_format ??
+            generatedResponseFormat?.toString() ??
+            GeneratedResponseFormat.url.name;
 
   Map<String, dynamic> toJson() => Map.of({
-    "prompt": this.prompt,
-    "n": this.n,
-    "size": this.size,
-    "response_format": this.response_format,
-    "user": this.user
-  });
+        "prompt": this.prompt,
+        "n": this.n,
+        "size": this.size,
+        "response_format": this.response_format,
+        "user": this.user
+      });
 }

--- a/lib/src/model/gen_image/request/generate_image.dart
+++ b/lib/src/model/gen_image/request/generate_image.dart
@@ -1,13 +1,14 @@
 ///The size of the generated images.
-enum GeneratedImageSize {
+enum GenerateImageSize {
   size1024("1024x1024"),
   size512("512x512"),
   size256("256x256");
 
-  const GeneratedImageSize(this.size);
+  const GenerateImageSize(this.size);
   final String size;
 }
 
+///The format in which the generated images are returned. Must be one of url or b64_json.
 enum GeneratedResponseFormat {
   url,
   b64_json;
@@ -33,7 +34,7 @@ class GenerateImage {
     this.prompt,
     this.n, {
     String? size,
-    GeneratedImageSize? generateImageSize,
+    GenerateImageSize? generateImageSize,
     String? response_format,
     GeneratedResponseFormat? generatedResponseFormat,
     this.user = "",
@@ -42,10 +43,20 @@ class GenerateImage {
         assert((response_format == null) || (generatedResponseFormat == null),
             'response_format and generatedResponseFormat  must not both be valid.'),
         assert(1 <= n && n <= 10, 'n must be between 1 and 10.'),
+        assert(
+            size == null ||
+                GenerateImageSize.values.map((e) => e.size).contains(size),
+            'size must be null or [${GenerateImageSize.values.map((e) => e.size).join(',')}]'),
+        assert(
+            response_format == null ||
+                GeneratedResponseFormat.values
+                    .map((e) => e.name)
+                    .contains(response_format),
+            'response_format($response_format) must be null or [${GeneratedResponseFormat.values.map((e) => e.name).join(',')}]'),
         this.size =
-            size ?? generateImageSize?.size ?? GeneratedImageSize.size1024.size,
+            size ?? generateImageSize?.size ?? GenerateImageSize.size1024.size,
         this.response_format = response_format ??
-            generatedResponseFormat?.toString() ??
+            generatedResponseFormat?.name ??
             GeneratedResponseFormat.url.name;
 
   Map<String, dynamic> toJson() => Map.of({

--- a/test/model/gen_image/request/generate_image_test.dart
+++ b/test/model/gen_image/request/generate_image_test.dart
@@ -11,4 +11,115 @@ main() {
     expect(target.response_format, 'url');
     expect(target.user, '');
   });
+
+  test('set value without enum', () async {
+    final target1 = GenerateImage('test', 2,
+        size: '256x256', response_format: 'b64_json', user: 'user');
+    expect(target1.prompt, 'test');
+    expect(target1.n, 2);
+
+    expect(target1.size, '256x256');
+    expect(target1.response_format, 'b64_json');
+    expect(target1.user, 'user');
+
+    final target2 = GenerateImage('test2', 3,
+        size: '512x512', response_format: 'url', user: 'user2');
+    expect(target2.prompt, 'test2');
+    expect(target2.n, 3);
+
+    expect(target2.size, '512x512');
+    expect(target2.response_format, 'url');
+    expect(target2.user, 'user2');
+  });
+
+  test('set value with enum', () async {
+    final target1 = GenerateImage('test', 1,
+        generateImageSize: GenerateImageSize.size256,
+        generatedResponseFormat: GeneratedResponseFormat.b64_json,
+        user: 'user');
+    expect(target1.prompt, 'test');
+    expect(target1.n, 1);
+
+    expect(target1.size, '256x256');
+    expect(target1.response_format, 'b64_json');
+    expect(target1.user, 'user');
+
+    final target2 = GenerateImage('test', 2,
+        generateImageSize: GenerateImageSize.size512,
+        generatedResponseFormat: GeneratedResponseFormat.url,
+        user: 'user');
+    expect(target2.size, '512x512');
+    expect(target2.response_format, 'url');
+
+    final target3 = GenerateImage('test', 1,
+        generateImageSize: GenerateImageSize.size1024, user: 'user');
+    expect(target3.size, '1024x1024');
+  });
+
+  group('response_format', () {
+    test('error', () {
+      try {
+        GenerateImage('test2', 3,
+            size: '512x512', response_format: 'b64json', user: 'user2');
+        fail('exception must be throw');
+      } on AssertionError catch (e) {
+        expect(e.message,
+            'response_format(b64json) must be null or [url,b64_json]');
+      } catch (e) {
+        fail('unexpected exception');
+      }
+    });
+  });
+
+  group('GeneratedImageSize', () {
+    test('normal', () async {
+      expect(GenerateImage('test', 2).size, '1024x1024');
+      expect(
+          GenerateImage('test', 2, generateImageSize: GenerateImageSize.size256)
+              .size,
+          '256x256');
+      expect(
+          GenerateImage('test', 2, generateImageSize: GenerateImageSize.size512)
+              .size,
+          '512x512');
+      expect(
+          GenerateImage('test', 2,
+                  generateImageSize: GenerateImageSize.size1024)
+              .size,
+          '1024x1024');
+    });
+
+    test('error', () {
+      expect(() => GenerateImage('test', 1, size: '1024x1023'),
+          throwsAssertionError);
+      expect(
+          () => GenerateImage('test', 1,
+              size: '1024x1024', generateImageSize: GenerateImageSize.size256),
+          throwsAssertionError);
+    });
+  });
+
+  test('n must be between 1 and 10', () {
+    expect(() => GenerateImage('test', 0), throwsAssertionError);
+    expect(() => GenerateImage('test', 11), throwsAssertionError);
+
+    expect(GenerateImage('test', 1).n, 1);
+    expect(GenerateImage('test', 10).n, 10);
+  });
+
+  group('toJson', () {
+    test('example', () {
+      final json = GenerateImage('test', 1,
+              generateImageSize: GenerateImageSize.size256,
+              generatedResponseFormat: GeneratedResponseFormat.b64_json,
+              user: 'user')
+          .toJson();
+
+      expect(json['prompt'], 'test');
+      expect(json['n'], 1);
+      expect(json['size'], '256x256');
+      expect(json['response_format'], 'b64_json');
+      expect(json['user'], 'user');
+    });
+  });
 }

--- a/test/model/gen_image/request/generate_image_test.dart
+++ b/test/model/gen_image/request/generate_image_test.dart
@@ -1,0 +1,14 @@
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+main() {
+  test('default value', () async {
+    final target = GenerateImage('test', 2);
+    expect(target.prompt, 'test');
+    expect(target.n, 2);
+
+    expect(target.size, '1024x1024');
+    expect(target.response_format, 'url');
+    expect(target.user, '');
+  });
+}


### PR DESCRIPTION
## Improve to GenerateImage
### Add enum
The developers have to pass strings for size and response_format as arguments to GenerateImage.
Generally, it is not a good idea to write strings, so set enums for the two.
- GenerateImageSize
- GeneratedResponseFormat

### Add assert
The arguments n, size, and reponse_format are not defined in the program, although it is written in the comments that only certain values are accepted.
Therefore, assert was added.

### Add test
GenerateImage did not have a test, so I added one. Coverage was set to 100%.

I hope you will consider this pull request and I will be happy to participate in the development in the future.