### PR TITLE
Add test for models

### DIFF
--- a/lib/src/model/chat_complete/response/chat_choice.dart
+++ b/lib/src/model/chat_complete/response/chat_choice.dart
@@ -5,8 +5,7 @@ class ChatChoice {
   final Message message;
   final String? finishReason;
 
-  ChatChoice(
-      {required this.index, required this.message, required this.finishReason});
+  ChatChoice({required this.index, required this.message, this.finishReason});
 
   factory ChatChoice.fromJson(Map<String, dynamic> json) => ChatChoice(
         index: json["index"],

--- a/lib/src/model/complete_text/request/complete_text.dart
+++ b/lib/src/model/complete_text/request/complete_text.dart
@@ -6,6 +6,7 @@ class CompleteText {
   final double topP;
   final double frequencyPenalty;
   final double presencePenalty;
+
   /// ### example use it
   /// - ["You:"]
   ///Q: Who is Batman?
@@ -14,19 +15,27 @@ class CompleteText {
   /// [" Human:", " AI:"]
   final List<String>? stop;
 
-  CompleteText({required this.prompt, required this.model,  this.temperature = .3,
-    this.maxTokens = 100, this.topP = 1.0, this.frequencyPenalty = .0 , this.presencePenalty = .0,this.stop});
+  CompleteText(
+      {required this.prompt,
+      required this.model,
+      this.temperature = .3,
+      this.maxTokens = 100,
+      this.topP = 1.0,
+      this.frequencyPenalty = .0,
+      this.presencePenalty = .0,
+      this.stop});
 
-  factory CompleteText.fromJson(Map<String,dynamic> json) => CompleteText(
-    prompt: json['prompt'] as String,
-    model: json['model'] as String,
-    temperature: (json['temperature'] as num?)?.toDouble() ?? .3,
-    maxTokens: json['max_tokens'] as int? ?? 100,
-    topP: (json['top_p'] as num?)?.toDouble() ?? 1.0,
-    frequencyPenalty: (json['frequency_penalty'] as num?)?.toDouble() ?? .0,
-    presencePenalty: (json['presence_penalty'] as num?)?.toDouble() ?? .0,
-  );
-  Map<String,dynamic> toJson() => completeReqToJson(this);
+  factory CompleteText.fromJson(Map<String, dynamic> json) => CompleteText(
+        prompt: json['prompt'] as String,
+        model: json['model'] as String,
+        temperature: (json['temperature'] as num?)?.toDouble() ?? .3,
+        maxTokens: json['max_tokens'] as int? ?? 100,
+        topP: (json['top_p'] as num?)?.toDouble() ?? 1.0,
+        frequencyPenalty: (json['frequency_penalty'] as num?)?.toDouble() ?? .0,
+        presencePenalty: (json['presence_penalty'] as num?)?.toDouble() ?? .0,
+        stop: (json['stop'] as List<String>?),
+      );
+  Map<String, dynamic> toJson() => completeReqToJson(this);
 
   Map<String, dynamic> completeReqToJson(CompleteText instance) =>
       <String, dynamic>{
@@ -39,5 +48,4 @@ class CompleteText {
         'presence_penalty': instance.presencePenalty,
         "stop": instance.stop
       };
-
 }

--- a/test/model/chat_complete/request/ChatCompleteText_test.dart
+++ b/test/model/chat_complete/request/ChatCompleteText_test.dart
@@ -1,0 +1,69 @@
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ChatCompleteText', () {
+    test('toJson returns the correct map', () {
+      final messages = [
+        {"speaker": "User", "text": "Hello!"},
+        {"speaker": "Bot", "text": "Hi there! How can I help you?"}
+      ];
+      final chatCompleteText = ChatCompleteText(
+          model: kChatGptTurboModel,
+          messages: messages,
+          temperature: 0.5,
+          topP: 0.9,
+          n: 2,
+          stream: true,
+          stop: ["User:"],
+          maxToken: 50,
+          presencePenalty: -0.5,
+          frequencyPenalty: 0.5,
+          user: "user123");
+
+      final expectedMap = {
+        "model": kChatGptTurboModel,
+        "messages": messages,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "n": 2,
+        "stream": true,
+        "stop": ["User:"],
+        "max_tokens": 50,
+        "presence_penalty": -0.5,
+        "frequency_penalty": 0.5,
+        "user": "user123"
+      };
+      expect(chatCompleteText.toJson(), expectedMap);
+    });
+
+    test('toJson() with default values', () {
+      final chatCompleteText = ChatCompleteText(
+        model: kChatGptTurboModel,
+        messages: [
+          {'speaker': 'user', 'text': 'Hello!'},
+          {'speaker': 'chatbot', 'text': 'Hi, how can I assist you today?'},
+        ],
+      );
+
+      final expectedJson = {
+        "model": kChatGptTurboModel,
+        "messages": [
+          {'speaker': 'user', 'text': 'Hello!'},
+          {'speaker': 'chatbot', 'text': 'Hi, how can I assist you today?'},
+        ],
+        "temperature": .3,
+        "top_p": 1.0,
+        "n": 1,
+        "stream": false,
+        "stop": null,
+        "max_tokens": 100,
+        "presence_penalty": .0,
+        "frequency_penalty": .0,
+        "user": "",
+      };
+
+      expect(chatCompleteText.toJson(), expectedJson);
+    });
+  });
+}

--- a/test/model/chat_complete/response/ChatCTResponse_test.dart
+++ b/test/model/chat_complete/response/ChatCTResponse_test.dart
@@ -1,0 +1,92 @@
+import 'package:chat_gpt_sdk/src/model/chat_complete/response/chat_choice.dart';
+import 'package:chat_gpt_sdk/src/model/chat_complete/response/message.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:chat_gpt_sdk/src/model/complete_text/response/usage.dart';
+
+void main() {
+  test('ChatCTResponse can be instantiated', () {
+    final ChatCTResponse chatCTResponse = ChatCTResponse(
+        id: "id_test",
+        object: "object_test",
+        created: 1,
+        choices: [
+          ChatChoice(
+            index: 0,
+            message: Message(
+              role: "role_test",
+              content: "content_test",
+            ),
+            finishReason: "finish_reason_test",
+          ),
+        ],
+        usage: Usage(10, 20, 30));
+
+    expect(chatCTResponse.id, "id_test");
+    expect(chatCTResponse.object, "object_test");
+    expect(chatCTResponse.created, 1);
+    expect(chatCTResponse.choices.length, 1);
+    expect(chatCTResponse.usage.promptTokens, 10);
+    expect(chatCTResponse.usage.completionTokens, 20);
+    expect(chatCTResponse.usage.totalTokens, 30);
+  });
+
+  test('ChatCTResponse can be instantiated from json', () {
+    final Map<String, dynamic> json = {
+      "id": "id_test",
+      "object": "object_test",
+      "created": 1,
+      "choices": [
+        {
+          "index": 0,
+          "message": {"role": "role_test", "content": "content_test"},
+          "finish_reason": "finish_reason_test"
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30
+      }
+    };
+
+    final ChatCTResponse chatCTResponse = ChatCTResponse.fromJson(json);
+
+    expect(chatCTResponse.id, "id_test");
+    expect(chatCTResponse.object, "object_test");
+    expect(chatCTResponse.created, 1);
+    expect(chatCTResponse.choices.length, 1);
+    expect(chatCTResponse.usage.promptTokens, 10);
+    expect(chatCTResponse.usage.completionTokens, 20);
+    expect(chatCTResponse.usage.totalTokens, 30);
+  });
+
+  test('toJson should return a map with the same fields', () {
+    final ChatCTResponse chatCTResponse = ChatCTResponse(
+      id: "id_test",
+      object: "object_test",
+      created: 1,
+      choices: [
+        ChatChoice(
+          index: 0,
+          message: Message(
+            role: "role_test",
+            content: "content_test",
+          ),
+          finishReason: "finish_reason_test",
+        ),
+      ],
+      usage: Usage(10, 20, 30),
+    );
+
+    final Map<String, dynamic> json = chatCTResponse.toJson();
+
+    expect(json["id"], "id_test");
+    expect(json["object"], "object_test");
+    expect(json["created"], 1);
+    expect(json["choices"].length, 1);
+    expect(json["usage"]["prompt_tokens"], 10);
+    expect(json["usage"]["completion_tokens"], 20);
+    expect(json["usage"]["total_tokens"], 30);
+  });
+}

--- a/test/model/chat_complete/response/chat_choice_test.dart
+++ b/test/model/chat_complete/response/chat_choice_test.dart
@@ -1,0 +1,49 @@
+import 'package:chat_gpt_sdk/src/model/chat_complete/response/chat_choice.dart';
+import 'package:chat_gpt_sdk/src/model/chat_complete/response/message.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('toJson', () {
+    test('toJson should return a valid JSON map', () {
+      final chatChoice = ChatChoice(
+          index: 0,
+          message: Message(role: 'user', content: 'Hello'),
+          finishReason: null);
+
+      final jsonMap = chatChoice.toJson();
+
+      expect(jsonMap, isA<Map<String, dynamic>>());
+      expect(jsonMap['index'], equals(0));
+      expect(jsonMap['finish_reason'], equals(''));
+      expect(jsonMap['message'], isA<Map<String, dynamic>>());
+      expect(jsonMap['message']['role'], equals('user'));
+      expect(jsonMap['message']['content'], equals('Hello'));
+    });
+  });
+
+  group('fromJson', () {
+    test('fromJson should decode JSON correctly', () {
+      final Map<String, dynamic> json = {
+        'index': 1,
+        'message': {'role': 'bot', 'content': 'Hello, world!'},
+        'finish_reason': null,
+      };
+
+      final chatChoice = ChatChoice.fromJson(json);
+
+      expect(chatChoice.index, 1);
+      expect(chatChoice.message.role, 'bot');
+      expect(chatChoice.message.content, 'Hello, world!');
+      expect(chatChoice.finishReason, null);
+    });
+
+    test('fromJson should fail if required field is missing', () {
+      final Map<String, dynamic> json = {
+        'index': 1,
+        'finish_reason': null,
+      };
+
+      expect(() => ChatChoice.fromJson(json), throwsA(isA<TypeError>()));
+    });
+  });
+}

--- a/test/model/chat_complete/response/message_test.dart
+++ b/test/model/chat_complete/response/message_test.dart
@@ -1,0 +1,18 @@
+import 'package:chat_gpt_sdk/src/model/chat_complete/response/message.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Message', () {
+    test('toJson() returns expected Map', () {
+      final message = Message(role: 'sender', content: 'Hello, world!');
+      expect(message.toJson(), {'role': 'sender', 'content': 'Hello, world!'});
+    });
+
+    test('fromJson() returns expected Message object', () {
+      final json = {'role': 'receiver', 'content': 'Hi there!'};
+      final message = Message.fromJson(json);
+      expect(message.role, 'receiver');
+      expect(message.content, 'Hi there!');
+    });
+  });
+}

--- a/test/model/client/http_setup_test.dart
+++ b/test/model/client/http_setup_test.dart
@@ -1,0 +1,27 @@
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HttpSetup', () {
+    test('default values', () {
+      final httpSetup = HttpSetup();
+      expect(httpSetup.sendTimeout, const Duration(seconds: 6));
+      expect(httpSetup.connectTimeout, const Duration(seconds: 6));
+      expect(httpSetup.receiveTimeout, const Duration(seconds: 6));
+      expect(httpSetup.proxy, '');
+    });
+
+    test('custom values', () {
+      final httpSetup = HttpSetup(
+        sendTimeout: const Duration(seconds: 10),
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 30),
+        proxy: 'http://myproxy.com',
+      );
+      expect(httpSetup.sendTimeout, const Duration(seconds: 10));
+      expect(httpSetup.connectTimeout, const Duration(seconds: 20));
+      expect(httpSetup.receiveTimeout, const Duration(seconds: 30));
+      expect(httpSetup.proxy, 'http://myproxy.com');
+    });
+  });
+}

--- a/test/model/complete_text/request/complete_text.dart
+++ b/test/model/complete_text/request/complete_text.dart
@@ -1,0 +1,68 @@
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CompleteText', () {
+    test('fromJson creates a valid instance', () {
+      final json = {
+        'prompt': 'Hello world!',
+        'model': 'davinci',
+        'temperature': 0.8,
+        'max_tokens': 150,
+        'top_p': 0.9,
+        'frequency_penalty': 0.5,
+        'presence_penalty': 0.5,
+        'stop': [' Human:', ' AI:']
+      };
+
+      final completeText = CompleteText.fromJson(json);
+
+      expect(completeText.prompt, 'Hello world!');
+      expect(completeText.model, 'davinci');
+      expect(completeText.temperature, 0.8);
+      expect(completeText.maxTokens, 150);
+      expect(completeText.topP, 0.9);
+      expect(completeText.frequencyPenalty, 0.5);
+      expect(completeText.presencePenalty, 0.5);
+      expect(completeText.stop, [' Human:', ' AI:']);
+    });
+
+    test('toJson returns a valid Map', () {
+      final completeText = CompleteText(
+        prompt: 'Hello world!',
+        model: 'davinci',
+        temperature: 0.8,
+        maxTokens: 150,
+        topP: 0.9,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        stop: [' Human:', ' AI:'],
+      );
+
+      final json = completeText.toJson();
+
+      expect(json['prompt'], 'Hello world!');
+      expect(json['model'], 'davinci');
+      expect(json['temperature'], 0.8);
+      expect(json['max_tokens'], 150);
+      expect(json['top_p'], 0.9);
+      expect(json['frequency_penalty'], 0.5);
+      expect(json['presence_penalty'], 0.5);
+      expect(json['stop'], [' Human:', ' AI:']);
+    });
+
+    test('constructor creates a valid instance with default values', () {
+      final completeText =
+          CompleteText(prompt: 'Hello world!', model: 'davinci');
+
+      expect(completeText.prompt, 'Hello world!');
+      expect(completeText.model, 'davinci');
+      expect(completeText.temperature, 0.3);
+      expect(completeText.maxTokens, 100);
+      expect(completeText.topP, 1.0);
+      expect(completeText.frequencyPenalty, 0.0);
+      expect(completeText.presencePenalty, 0.0);
+      expect(completeText.stop, isNull);
+    });
+  });
+}

--- a/test/model/complete_text/response/usage_test.dart
+++ b/test/model/complete_text/response/usage_test.dart
@@ -1,0 +1,47 @@
+import 'package:chat_gpt_sdk/src/model/complete_text/response/usage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('fromJson', () {
+    test('should create a Usage object from a valid json', () {
+      final json = {
+        "prompt_tokens": 50,
+        "completion_tokens": 10,
+        "total_tokens": 60,
+      };
+
+      final usage = Usage.fromJson(json);
+
+      expect(usage.promptTokens, 50);
+      expect(usage.completionTokens, 10);
+      expect(usage.totalTokens, 60);
+    });
+
+    test(
+        'should create a Usage object from a valid json without completion tokens',
+        () {
+      final json = {
+        "prompt_tokens": 50,
+        "total_tokens": 50,
+      };
+
+      final usage = Usage.fromJson(json);
+
+      expect(usage.promptTokens, 50);
+      expect(usage.completionTokens, 0);
+      expect(usage.totalTokens, 50);
+    });
+  });
+
+  group('toJson', () {
+    test('should create a valid json from a Usage object', () {
+      final usage = Usage(50, 10, 60);
+
+      final json = usage.toJson();
+
+      expect(json['prompt_tokens'], 50);
+      expect(json['completion_tokens'], 10);
+      expect(json['total_tokens'], 60);
+    });
+  });
+}


### PR DESCRIPTION
Add test for ChatChoice, CompleteText, ChatCompleteText, ChatCTResponse, ChatChoice, Message, HttpSetup, CompleteText and Usage.

Added stop in CompleteText.fromJson since it was not converted.
Change argument "ChatChoice.finishReason" to non-required because on-requirements do not change behavior.














