### PR TITLE
fix #69: missing first word in sse response for example_app

### DIFF
--- a/example_app/openai_app/lib/bloc/openai/openai_bloc.dart
+++ b/example_app/openai_app/lib/bloc/openai/openai_bloc.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
@@ -135,11 +136,9 @@ class OpenAIBloc extends Cubit<OpenAIState> {
         }
         return false;
       });
-
       ///+= message
-      message?.message =
-          '${message?.message ?? ""}${it.choices.last.message?.content ?? ""}';
-      list.add(Message(isBot: true, id: '${it.id}', message: message?.message));
+      String msg = '${message?.message ?? ""}${it.choices.last.message?.content ?? ""}';
+      list.add(Message(isBot: true, id: '${it.id}', message: msg));
       emit(ChatCompletionState(
           isBot: true, messages: list, showStopButton: true));
     }, onDone: () {


### PR DESCRIPTION
The example app will retrieve the corresponding item with the `message.id` from the `list` after each response is returned, and append the returned content to it. However, the first response is discarded (because the message object is null, so the `message?.message = ....` does not function properly).

After merging PR #80, due to the SSE fix, the first response that sets the role (where message is empty) can now correctly return to the example app. Therefore, even if the example app discards the message from the first return, there is no significant impact. However, this is not reasonable, so a fix is needed for this issue.